### PR TITLE
Fix for iterator() of IntMap.Values and LongMap.Values, plus a test. …

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/IntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntMap.java
@@ -559,6 +559,7 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 			int i = currentIndex;
 			if (i == INDEX_ZERO && map.hasZeroValue) {
 				map.hasZeroValue = false;
+				map.zeroValue = null;
 			} else if (i < 0) {
 				throw new IllegalStateException("next must be called before remove.");
 			} else {

--- a/gdx/src/com/badlogic/gdx/utils/LongMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/LongMap.java
@@ -558,6 +558,7 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 			int i = currentIndex;
 			if (i == INDEX_ZERO && map.hasZeroValue) {
 				map.hasZeroValue = false;
+				map.zeroValue = null;
 			} else if (i < 0) {
 				throw new IllegalStateException("next must be called before remove.");
 			} else {

--- a/gdx/test/com/badlogic/gdx/utils/MixedPutRemoveTest.java
+++ b/gdx/test/com/badlogic/gdx/utils/MixedPutRemoveTest.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.HashMap;
+import java.util.Iterator;
 
 public class MixedPutRemoveTest {
 	@Test
@@ -45,6 +46,40 @@ public class MixedPutRemoveTest {
 		Assert.assertEquals(gdxRemovals, jdkRemovals);
 	}
 	@Test
+	public void testLongMapIterator() {
+		LongMap<Long> gdxMap = new LongMap<Long>();
+		long stateA = 0L, stateB = 1L, temp;
+		int actualSize = 0;
+		long item;
+		for (int i = 0; i < 0x10000; i++) { // 64K should do
+			// simple-ish RNG that repeats more than RandomXS128; we want repeats to test behavior
+			stateA += 0xC6BC279692B5C323L;
+			item = (stateA ^ stateA >>> 31) * (stateB += 0x9E3779B97F4A7C16L);
+			item &= item >>> 24; // causes 64-bit state to get crammed into 40 bits, with item biased toward low bit counts
+			if(gdxMap.put(item, item) == null) actualSize++;
+			if(actualSize % 6 == 5) {
+				Iterator<Long> it = gdxMap.values().iterator();
+				for (int n = (int)(item & 3) + 1; n > 0; n--) {
+					it.next();
+				}
+				it.remove();
+				actualSize--;
+				//repeat above RNG
+				for (int j = 0; j < 2; j++) {
+					stateA += 0xC6BC279692B5C323L;
+					item = (stateA ^ stateA >>> 31) * (stateB += 0x9E3779B97F4A7C16L);
+					item &= item >>> 24;
+					if (gdxMap.put(item, item) == null)
+						actualSize++;
+				}
+			}
+			Assert.assertEquals(gdxMap.size, actualSize);
+		}
+		for(LongMap.Entry<Long> ent : gdxMap){
+			Assert.assertEquals(ent.key, ent.value.longValue());
+		}
+	}
+	@Test
 	public void testIntMapPut() {
 		IntMap<Integer> gdxMap = new IntMap<Integer>();
 		HashMap<Integer, Integer> jdkMap = new HashMap<Integer, Integer>();
@@ -81,6 +116,40 @@ public class MixedPutRemoveTest {
 			Assert.assertEquals(gdxMap.size, jdkMap.size());
 		}
 		Assert.assertEquals(gdxRemovals, jdkRemovals);
+	}
+	@Test
+	public void testIntMapIterator() {
+		IntMap<Integer> gdxMap = new IntMap<Integer>();
+		long stateA = 0L, stateB = 1L, temp;
+		int gdxRemovals = 0, actualSize = 0;
+		int item;
+		for (int i = 0; i < 0x10000; i++) { // 64K should do
+			// simple-ish RNG that repeats more than RandomXS128; we want repeats to test behavior
+			stateA += 0xC6BC279692B5C323L;
+			temp = (stateA ^ stateA >>> 31) * (stateB += 0x9E3779B97F4A7C16L);
+			item = (int)(temp & temp >>> 24); // causes 64-bit state to get crammed into 32 bits, with item biased toward low bit counts
+			if(gdxMap.put(item, item) == null) actualSize++;
+			if(actualSize % 6 == 5) {
+				Iterator<Integer> it = gdxMap.values().iterator();
+				for (int n = (int)(temp & 3) + 1; n > 0; n--) {
+					it.next();
+				}
+				it.remove();
+				actualSize--;
+				//repeat above RNG
+				for (int j = 0; j < 2; j++) {
+					stateA += 0xC6BC279692B5C323L;
+					temp = (stateA ^ stateA >>> 31) * (stateB += 0x9E3779B97F4A7C16L);
+					item = (int)(temp & temp >>> 24);
+					if (gdxMap.put(item, item) == null)
+						actualSize++;
+				}
+			}
+			Assert.assertEquals(gdxMap.size, actualSize);
+		}
+		for(IntMap.Entry<Integer> ent : gdxMap){
+			Assert.assertEquals(ent.key, ent.value.intValue());
+		}
 	}
 	@Test
 	public void testObjectMapPut() {


### PR DESCRIPTION
…(#6475)

* Improve MathUtils.asin(), acos()

The average and largest error are significantly better for this version (2-3 orders of magnitude), and it can be slightly faster.

* Fix missing check for INDEX_ZERO in IntIntMap, IntFloatMap.

This fixes #6347 . Thanks @tomcashman , for making this an easy fix!

* Mark key/value/entry/iterator fields as transient.

This stops a bad StackOverflowException from happening when some Map or Set types are iterated over and then written with Json. That happens in all stable versions I've tried between 1.9.6 and 1.9.13, on at least IntIntMap but probably also IntFloatMap and ObjectLongMap.

A better alternative would be to add special-case Json handling like IntMap, ObjectIntMap, and LongMap have for the other primitive-backed maps, since that would make the output much cleaner, smaller, and more readable. At one point, the special-case handling I wrote was in my PR that introduced these updated data structrures, but adding that was overruled, and the serialization code was removed without `transient` being added in its place to fields that cause problems during "vanilla" serialization.

* Fix getIndices() crash in Mesh, credit to Agueliethun

This was probably a copy/paste error, but the getIndices() code mistakenly changed the vertices buffer where it formerly changed only the indices buffer. This caused crashes in ModelCacheTest when the Cache checkbox was selected and any model was added.

* First, the test that shows an issue...

Thanks to Discord user vladimir for finding a remaining part of an issue with IntMap and LongMap, this time in the iterator() of their Values (maybe also Keys) when using remove() . Here, the sizes aren't as expected after over 9K items have been placed (actualSize is 9282 when the problem happens, but the correct value is 9283).

* In IntMap/LongMap, null out zeroValue when it is removed.

This seems to be relevant to the return value when you `put(0, something)` after that 0-key has already been put and removed. I think this fixes vladimir's bug with the Values iterator().